### PR TITLE
Rebuild  `Libutf8proc` version `2.6.1` for `win-64`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4c06a9dc4017e8a2438ef80ee371d45868bda2237a98b26554de7a95406b283b
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # Appears to have pretty good compatibility.
     # ref: https://abi-laboratory.pro/?view=timeline&l=utf8proc


### PR DESCRIPTION
`Rebuild libutf8proc 2.6.1`

The package is currently missing for `windows-64`

This is a dependency that will be needed to build `arrow-cpp` version `10.0.0` in `windows-64`.

---


`libutf8proc` version `2.6.1`
1. - [X] Check the upstream
    https://github.com/JuliaStrings/utf8proc/tree/v2.6.1
2. - [X] Check the pinnings
3. - [X] Check the changelogs
    https://github.com/JuliaStrings/utf8proc/blob/v2.6.1/NEWS.md
4. - [X] Additional research
    https://github.com/conda-forge/libutf8proc-feedstock/issues
    
    There are currently no open issues at the time of the review
5. - [X] Verify the `dev_url`
    https://github.com/JuliaStrings/utf8proc
6. - [X] Verify the `doc_url`
    https://juliastrings.github.io/utf8proc/doc/
7. - [X] License is `spdx` compliant
    MIT
8. - [X] License family is present
    MIT
9. - [X] Verify that the `build_number` is correct
    The build number was incremented since the version is already present for other architectures.
10. - [X] Verify if the package needs `setuptools`
    the package is a c package it does not need setuptools
11. - [X] Verify if the package needs `wheel`
    the package is a c package it does not need wheel
12. - [X] `pip` in the test section
    the package is a c package it does not need pip
13. - [X] Veriy the test section
14. - [X] Verify if the package is `architecture specific` or `Noarch`
    The package is architecture specific
15. - [X] Verify that private modules are not mentioned on the recipe For example: (_private_module)
 
Results:
- 
 
 
Based on the research findings the results we can conclude
that it is safe to rebuild `libutf8proc` version `2.6.1`

