### PR TITLE
libutf8proc 2.11.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - cmake
+    - cmake >=3.10
     - make   # [not win]
     - m2-make   # [win]
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - cmake >=3.10
     - make   # [not win]
     - m2-make   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
     - cmake >=3.10
-    - make
+    - make   # [not win]
+    - m2-make   # [win]
   host:
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ stdlib('c') }}
     - cmake >=3.10
-    - make   # [not win]
-    - m2-make   # [win]
+    - make
   host:
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libutf8proc" %}
-{% set version = "2.6.1" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/JuliaStrings/utf8proc/archive/v{{ version }}.tar.gz
-  sha256: 4c06a9dc4017e8a2438ef80ee371d45868bda2237a98b26554de7a95406b283b
+  sha256: c24379b5fa0a429a1f9a3fc23b44a75f2b141a34c09146a529a55d20a5808070
 
 build:
-  number: 1
+  number: 0
   run_exports:
     # Appears to have pretty good compatibility.
     # ref: https://abi-laboratory.pro/?view=timeline&l=utf8proc


### PR DESCRIPTION
libutf8proc 2.11.0 

**Destination channel:** Defaults

### Links

- [PKG-9642]
- dev_url:        https://github.com/JuliaStrings/utf8proc/tree/v2.11.0
- conda_forge:    https://github.com/conda-forge/libutf8proc-feedstock
- pypi:           https://pypi.org/project/libutf8proc/2.11.0
- pypi inspector: https://inspector.pypi.io/project/libutf8proc/2.11.0

### Explanation of changes:

- new version number


[PKG-9642]: https://anaconda.atlassian.net/browse/PKG-9642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ